### PR TITLE
Updates the deletion of posts and comments

### DIFF
--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -24,14 +24,27 @@ export function startLoadingPost() {
   }
 }
 
+// export function startRemovingPost(index, id){
+//   return (dispatch) => {
+//     return database.ref(`posts/${id}`).remove().then(()=>{
+//       dispatch(removePost(index))
+//     }).catch((error) => {
+//       console.log(error)
+//     })
+//   }
+// }
 export function startRemovingPost(index, id){
+  const updates = {
+    [`posts/${id}`]: null,
+    [`comments/${id}`]: null
+  }
   return (dispatch) => {
-    return database.ref(`posts/${id}`).remove().then(()=>{
+    return database.ref().update(updates).then(() => {
       dispatch(removePost(index))
     }).catch((error) => {
       console.log(error)
     })
-  }
+  } 
 }
 
 export function startAddingComment(comment, postId){


### PR DESCRIPTION
Posts would delete with out comments deleting. When I added the update method and an object of both posts and comments ids then the post and comment would delete with their respective id correlation.